### PR TITLE
chore(README): 更正README链接指向

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ SMTP Port: 25/465(SSL)
 
 [WeChat Push](server/hooks/wechat_push/README.md)
 
-[Telegram Push](server/hooks/wechat_push/README.md)
+[Telegram Push](server/hooks/telegram_push/README.md)
 
-[Web Push](server/hooks/wechat_push/README.md)
+[Web Push](server/hooks/web_push/README.md)
 
 ## Plugin Install
 > [!IMPORTANT]

--- a/README_CN.md
+++ b/README_CN.md
@@ -106,9 +106,9 @@ SMTP端口： 25/465(SSL)
 
 [微信推送](server/hooks/wechat_push/README.md)
 
-[Telegram推送](server/hooks/wechat_push/README.md)
+[Telegram推送](server/hooks/telegram_push/README.md)
 
-[WebHook推送](server/hooks/wechat_push/README.md)
+[WebHook推送](server/hooks/web_push/README.md)
 
 ## 插件安装
 > [!IMPORTANT]


### PR DESCRIPTION
README中，Telegram和Webhook推送的指引链接都指向了微信推送