### PR TITLE
fix: 修复 db_dsn 为空的错误

### DIFF
--- a/fe/src/i18n/i18n.js
+++ b/fe/src/i18n/i18n.js
@@ -105,7 +105,8 @@ var lang = {
     "move":"Move to group",
     "del_rule_confirm":"Are you sure to delete this?",
     "rule_params":"Executed params",
-    "autoSSLWarn":"PMail is not currently running on port 80. If you want PMail to manage SSL certificates automatically, please forward the /.well-known/* route to PMail. See https://github.com/Jinnrry/PMail/issues/94 for details."
+    "autoSSLWarn": "PMail is not currently running on port 80. If you want PMail to manage SSL certificates automatically, please forward the /.well-known/* route to PMail. See https://github.com/Jinnrry/PMail/issues/94 for details.",
+    "err_db_dsn_empty": "Database path cannot be empty!",
 };
 
 
@@ -217,7 +218,8 @@ var zhCN = {
     "move":"移动分组",
     "del_rule_confirm":"确定要删除吗？",
     "rule_params":"执行参数",
-    "autoSSLWarn":"PMail当前未使用80端口启动，如果想要PMail自动管理SSL证书，请将/.well-known/*路由转发到PMail。 详见https://github.com/Jinnrry/PMail/issues/94"
+    "autoSSLWarn": "PMail当前未使用80端口启动，如果想要PMail自动管理SSL证书，请将/.well-known/*路由转发到PMail。 详见https://github.com/Jinnrry/PMail/issues/94",
+    "err_db_dsn_empty": "数据库路径不能为空!",
 }
 
 switch (navigator.language) {
@@ -230,7 +232,5 @@ switch (navigator.language) {
     default:
         break
 }
-
-
 
 export default lang;

--- a/fe/src/views/SetupView.vue
+++ b/fe/src/views/SetupView.vue
@@ -342,6 +342,13 @@ const getDomainConfig = () => {
 }
 
 const setDbConfig = () => {
+    // 切换数据库类型为sqlite时，数据库路径为空，则使用默认路径
+    if (dbSettings.type === "sqlite" && !dbSettings.dsn) dbSettings.dsn = "./config/pmail.db";
+    else if (!dbSettings.dsn) ElMessage({
+        title: "Error",
+        message: lang.err_db_dsn_empty,
+        type: "error",
+    });
     $http.post("/api/setup", { "action": "set", "step": "database", "db_type": dbSettings.type, "db_dsn": dbSettings.dsn }).then((res) => {
         if (res.errorNo != 0) {
             ElMessage.error(res.errorMsg)


### PR DESCRIPTION
1. 在切换数据库类型时, sqlite 的存储位置会被清空. 现于 placeholder 保持一致.

![image](https://github.com/user-attachments/assets/76cab970-2522-4785-a4e3-cce4155b62b3)
