### PR TITLE
在md文档中使用jsonc解决注释报红的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ use [https://www.mail-tester.com/](https://www.mail-tester.com/) for checking.
 
 # Configuration file format description
 
-```json
+```jsonc
 {
   "logLevel": "info", //log output level
   "domain": "domain.com", // Your domain

--- a/README_CN.md
+++ b/README_CN.md
@@ -80,7 +80,7 @@ PMail是一个追求极简部署流程、极致资源占用的个人域名邮箱
 
 # 配置文件说明
 
-```json
+```jsonc
 {
   "logLevel": "info", //日志输出级别
   "domain": "domain.com", // 你的域名

--- a/server/hooks/spam_block/README.md
+++ b/server/hooks/spam_block/README.md
@@ -35,7 +35,7 @@ curl -X POST http://localhost:8501/v1/models/emotion_model:predict -d '{
 
 将得到类似输出：
 
-```json
+```jsonc
 {
   "predictions": [
     [

--- a/server/hooks/telegram_push/README.md
+++ b/server/hooks/telegram_push/README.md
@@ -6,7 +6,7 @@ Copy plugin binary file to `/plugins`
 
 add config.json to `/plugins/config.com` like this:
 
-```json
+```jsonc
 {
   "tgChatId": "", // telegram  chatid
   "tgBotToken": "", // telegram   token

--- a/server/hooks/wechat_push/README.md
+++ b/server/hooks/wechat_push/README.md
@@ -9,7 +9,7 @@ add config.json to `/plugins/config.com` like this:
 
 新建配置文件`/plugins/config.com`，内容如下
 
-```json
+```jsonc
 {
   "weChatPushAppId": "", // wechat appid
   "weChatPushSecret": "", // weChat  Secret


### PR DESCRIPTION
在 md 文档中使用 json 代码块会导致注释全部报红，很难看，改用 jsonc 即可。