### PR TITLE
Change label addition method on test failure

### DIFF
--- a/.github/workflows/unitTest.yml
+++ b/.github/workflows/unitTest.yml
@@ -47,12 +47,9 @@ jobs:
 
       - name: Pull Request Labeler
         if: ${{ failure() }}
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: 'add-labels'
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.pull_request.number }}
-          labels: 'Auto: Test Failed'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr edit ${{ github.event.pull_request.number }} --add-label "Auto: Test Failed"
         
       - name: Install Dependencies
         run: npm install --global yarn


### PR DESCRIPTION
Replaced action for adding labels on test failure with a command using GitHub CLI.