### PR TITLE
修复邮件详情与规则更新的水平越权漏洞

### DIFF
--- a/server/controllers/rule.go
+++ b/server/controllers/rule.go
@@ -61,7 +61,7 @@ func UpsertRule(ctx *context.Context, w http.ResponseWriter, req *http.Request) 
 func save(ctx *context.Context, p *models.Rule) error {
 
 	if p.Id > 0 {
-		_, err := db.Instance.Exec(db.WithContext(ctx, "update rule set name=? ,value = ? ,action = ?,params = ?,sort = ? where id = ?"), p.Name, p.Value, p.Action, p.Params, p.Sort, p.Id)
+		_, err := db.Instance.Exec(db.WithContext(ctx, "update rule set name=? ,value = ? ,action = ?,params = ?,sort = ? where id = ? and user_id = ?"), p.Name, p.Value, p.Action, p.Params, p.Sort, p.Id, ctx.UserID)
 		if err != nil {
 			return errors.Wrap(err)
 		}

--- a/server/services/detail/detail.go
+++ b/server/services/detail/detail.go
@@ -20,7 +20,7 @@ import . "xorm.io/builder"
 func GetEmailDetail(ctx *context.Context, id int, markRead bool) (*response.EmailResponseData, error) {
 	// 先查是否是本人的邮件
 	var ue models.UserEmail
-	_, err := db.Instance.Where("email_id = ?", id).Get(&ue)
+	_, err := db.Instance.Where("email_id = ? AND user_id = ?", id, ctx.UserID).Get(&ue)
 	if err != nil {
 		log.Error(err)
 	}


### PR DESCRIPTION
  修复两个普通用户可利用的水平越权漏洞。

  - 邮件详情查询改为按 `(email_id, user_id)` 校验归属关系。
    该修复覆盖共用详情服务的 Web API，以及 POP3 `LIST`、`RETR`、`TOP` 命令；管理员读取权限保持不变。
  - 邮件规则更新改为使用 `WHERE id = ? AND user_id = ?`。
    防止跨账号篡改邮件规则，避免攻击者将他人规则修改为恶意转发。