### PR TITLE
fix: 修复 SpamBlock 配置越权

### DIFF
--- a/server/hooks/spam_block/spam_block.go
+++ b/server/hooks/spam_block/spam_block.go
@@ -63,6 +63,9 @@ func (s *SpamBlock) SettingsHtml(ctx *context.Context, url string, requestData s
 		}
 		return fmt.Sprintf(index, s.cfg.ApiURL, s.cfg.ApiTimeout, s.cfg.Threshold)
 	}
+	if !ctx.IsAdmin {
+		return "No Access Privileges"
+	}
 
 	var cfg SpamBlockConfig
 	var tempCfg map[string]string

--- a/server/hooks/spam_block/spam_block_test.go
+++ b/server/hooks/spam_block/spam_block_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/Jinnrry/pmail/utils/context"
+)
+
+func TestSettingsHtmlRejectsNonAdminSave(t *testing.T) {
+	s := &SpamBlock{}
+	result := s.SettingsHtml(&context.Context{}, "SpamBlock/save", `{"url":"https://model.example.com/predict"}`)
+	if result != "No Access Privileges" {
+		t.Fatalf("non-admin save result = %q, want access denial", result)
+	}
+	if s.cfg.ApiURL != "" {
+		t.Fatal("non-admin save changed the configuration")
+	}
+}


### PR DESCRIPTION
非管理员用户理论上不能访问 SpamBlock 配置。但配置保存路径只存在前端的IsAdmin校验，后端save接口未校验。

在 SpamBlock 配置保存路径增加管理员校验