### PR TITLE
fix(email): 修复重建 Date 邮件头时丢失时区

### DIFF
--- a/server/dto/parsemail/email.go
+++ b/server/dto/parsemail/email.go
@@ -234,7 +234,7 @@ func NewEmailFromModel(d models.Email) *Email {
 		Bcc:         Bcc,
 		Cc:          Cc,
 		Attachments: Attachments,
-		Date:        d.SendDate.Format("2006-01-02 15:04:05"),
+		Date:        d.SendDate.Format(time.RFC3339),
 	}
 	if d.Type == 0 {
 		ret.Authentication = NewEmailAuthentication(d.SPFCheck == 1, d.DKIMCheck == 1)
@@ -290,7 +290,7 @@ func NewEmailFromReader(to []string, r io.Reader, size int) *Email {
 	if err != nil {
 		sendTime = time.Now()
 	}
-	ret.Date = sendTime.Format(time.DateTime)
+	ret.Date = sendTime.Format(time.RFC3339)
 	m.Walk(func(path []int, entity *message.Entity, err error) error {
 		return formatContent(entity, ret)
 	})
@@ -614,7 +614,11 @@ func (e *Email) BuildBytes(ctx *context.Context, dkim bool) []byte {
 	// Create our mail header
 	var h mail.Header
 	if e.Date != "" {
-		t, err := time.ParseInLocation("2006-01-02 15:04:05", e.Date, time.Local)
+		t, err := time.Parse(time.RFC3339, e.Date)
+		if err != nil {
+			// Keep compatibility with Date values stored before timezone offsets were preserved.
+			t, err = time.ParseInLocation(time.DateTime, e.Date, time.Local)
+		}
 		if err != nil {
 			log.WithContext(ctx).Errorf("Time Error ! Err:%+v", err)
 			h.SetDate(time.Now())

--- a/server/dto/parsemail/email_test.go
+++ b/server/dto/parsemail/email_test.go
@@ -3,12 +3,102 @@ package parsemail
 import (
 	"bytes"
 	"fmt"
-	"github.com/emersion/go-message"
 	"io"
+	stdmail "net/mail"
 	"strings"
-
 	"testing"
+	"time"
+
+	"github.com/Jinnrry/pmail/models"
+	"github.com/emersion/go-message"
 )
+
+func builtMessageDate(t *testing.T, raw []byte) time.Time {
+	t.Helper()
+
+	m, err := stdmail.ReadMessage(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("read built message: %v", err)
+	}
+	date, err := stdmail.ParseDate(m.Header.Get("Date"))
+	if err != nil {
+		t.Fatalf("parse built Date header %q: %v", m.Header.Get("Date"), err)
+	}
+	return date
+}
+
+func TestEmailDateFromReaderPreservesInstant(t *testing.T) {
+	const dateHeader = "Sun, 09 Aug 2026 11:51:08 +0000"
+	raw := []byte("From: sender@example.com\r\n" +
+		"To: recipient@example.com\r\n" +
+		"Subject: Date round trip\r\n" +
+		"Date: " + dateHeader + "\r\n" +
+		"Message-ID: <date-reader@example.com>\r\n" +
+		"Content-Type: text/plain; charset=UTF-8\r\n\r\n" +
+		"body")
+
+	expected, err := stdmail.ParseDate(dateHeader)
+	if err != nil {
+		t.Fatalf("parse fixture date: %v", err)
+	}
+
+	email := NewEmailFromReader([]string{"recipient@example.com"}, bytes.NewReader(raw), len(raw))
+	stored, err := time.Parse(time.RFC3339, email.Date)
+	if err != nil {
+		t.Fatalf("stored Date is not RFC3339: %q: %v", email.Date, err)
+	}
+	if !stored.Equal(expected) {
+		t.Fatalf("stored Date changed instant: got %s, want %s", stored, expected)
+	}
+
+	got := builtMessageDate(t, email.BuildBytes(nil, false))
+	if !got.Equal(expected) {
+		t.Fatalf("rebuilt Date changed instant: got %s, want %s", got, expected)
+	}
+}
+
+func TestEmailDateFromModelPreservesUTCInstant(t *testing.T) {
+	expected := time.Date(2026, time.August, 9, 11, 51, 8, 0, time.UTC)
+	email := NewEmailFromModel(models.Email{
+		Id:          1,
+		FromAddress: "sender@example.com",
+		To:          `[{"EmailAddress":"recipient@example.com","Name":""}]`,
+		Subject:     "Model date",
+		SendDate:    expected,
+		MsgID:       "date-model@example.com",
+	})
+
+	if email.Date != expected.Format(time.RFC3339) {
+		t.Fatalf("model Date = %q, want %q", email.Date, expected.Format(time.RFC3339))
+	}
+
+	got := builtMessageDate(t, email.BuildBytes(nil, false))
+	if !got.Equal(expected) {
+		t.Fatalf("rebuilt model Date changed instant: got %s, want %s", got, expected)
+	}
+}
+
+func TestEmailBuildBytesAcceptsLegacyDate(t *testing.T) {
+	const legacyDate = "2026-08-09 11:51:08"
+	expected, err := time.ParseInLocation(time.DateTime, legacyDate, time.Local)
+	if err != nil {
+		t.Fatalf("parse legacy fixture date: %v", err)
+	}
+
+	email := &Email{
+		From:    buildUser("sender@example.com"),
+		To:      buildUsers([]string{"recipient@example.com"}),
+		Subject: "Legacy date",
+		Text:    []byte("body"),
+		Date:    legacyDate,
+		MsgID:   "date-legacy@example.com",
+	}
+
+	got := builtMessageDate(t, email.BuildBytes(nil, false))
+	if !got.Equal(expected) {
+		t.Fatalf("legacy Date changed instant: got %s, want %s", got, expected)
+	}
+}
 
 func TestHtmlTxtAttachment(t *testing.T) {
 	emailBytes := `From: "=?utf-8?B?amlubnJyeQ==?=" <ok@xjiangwei.cn>


### PR DESCRIPTION
## 概要

- 保存收到邮件的 `Date` 邮件头时保留时区偏移。
- 将数据库模型转换回内部邮件类型时保留时间的时区信息。
- 重建 MIME 邮件时优先解析新的 RFC3339 时间格式。
- 继续兼容历史 `YYYY-MM-DD HH:MM:SS` 格式，并维持原有的本地时区解释方式。

## 问题

`NewEmailFromReader` 会把 RFC 5322 `Date` 邮件头解析成 `time.Time`，随后却使用 `time.DateTime` 格式保存。该格式不包含时区偏移。`BuildBytes` 重建邮件时，又使用 `time.Local` 解释同一个墙上时间，因此可能改变这个时间所代表的绝对时刻。

例如，输入时间 `Sun, 09 Aug 2026 11:51:08 +0000` 可能被重建成 `Sun, 09 Aug 2026 11:51:08 +0800`，使邮件头表示的绝对时刻向前偏移 8 小时，最终导致邮件客户端把刚收到的邮件显示为约 8 小时前发送。

`NewEmailFromModel` 也存在相同问题，因为它同样会把 `SendDate` 格式化为不含时区偏移的字符串。

## 修复方式

使用 RFC3339 保存解析得到的时间和模型时间，从而保留时区偏移。`BuildBytes` 重建邮件时优先按 RFC3339 解析；如果解析失败，再回退到历史无时区格式，确保数据库中已有的旧邮件仍能正常读取和重建。

## 测试

- 验证邮件从读取到重建的完整过程不会改变原始绝对时刻。
- 验证 UTC 时区的 `models.Email.SendDate` 重建后仍表示同一个绝对时刻。
- 验证历史无时区 Date 数据仍按 `time.Local` 正常重建。

已执行：

```text
TZ=Asia/Shanghai go test ./dto/parsemail -run 'TestEmail(DateFromReaderPreservesInstant|DateFromModelPreservesUTCInstant|BuildBytesAcceptsLegacyDate)$' -count=1
TZ=Asia/Shanghai go test ./dto/parsemail -count=1
git diff --check
```