### PR TITLE
fix(smtp): 出站SMTP连接增加30秒事务超时，防止下游无响应导致永久卡死

### DIFF
--- a/server/utils/smtp/smtp.go
+++ b/server/utils/smtp/smtp.go
@@ -36,7 +36,11 @@ import (
 var NoSupportSTARTTLSError = errors.New("smtp: server doesn't support STARTTLS")
 var EOFError = errors.New("EOF")
 
-const outboundSMTPQuitWriteTimeout = 250 * time.Millisecond
+const (
+	outboundSMTPDialTimeout        = 2 * time.Second
+	outboundSMTPTransactionTimeout = 30 * time.Second
+	outboundSMTPQuitWriteTimeout   = 250 * time.Millisecond
+)
 
 // A Client represents a client connection to an SMTP server.
 type Client struct {
@@ -61,7 +65,7 @@ type Client struct {
 // Dial returns a new Client connected to an SMTP server at addr.
 // The addr must include a port, as in "mail.example.com:smtp".
 func Dial(addr, fromDomain string) (*Client, error) {
-	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	conn, err := net.DialTimeout("tcp", addr, outboundSMTPDialTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +85,7 @@ func DialTls(addr, domain, fromDomain string) (*Client, error) {
 		ServerName:         domain,
 	}
 
-	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: 2 * time.Second}, "tcp", addr, tlsconfig)
+	conn, err := tls.DialWithDialer(&net.Dialer{Timeout: outboundSMTPDialTimeout}, "tcp", addr, tlsconfig)
 	if err != nil {
 		return nil, err
 	}
@@ -92,6 +96,15 @@ func DialTls(addr, domain, fromDomain string) (*Client, error) {
 // NewClient returns a new Client using an existing connection and host as a
 // server name to be used when authenticating.
 func NewClient(conn net.Conn, host, fromDomain string) (*Client, error) {
+	return newClientWithTimeout(conn, host, fromDomain, outboundSMTPTransactionTimeout)
+}
+
+func newClientWithTimeout(conn net.Conn, host, fromDomain string, timeout time.Duration) (*Client, error) {
+	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
 	text := textproto.NewConn(conn)
 	_, _, err := text.ReadResponse(220)
 	if err != nil {

--- a/server/utils/smtp/smtp.go
+++ b/server/utils/smtp/smtp.go
@@ -37,9 +37,31 @@ var NoSupportSTARTTLSError = errors.New("smtp: server doesn't support STARTTLS")
 var EOFError = errors.New("EOF")
 
 const (
-	outboundSMTPDialTimeout        = 2 * time.Second
-	outboundSMTPTransactionTimeout = 30 * time.Second
-	outboundSMTPQuitWriteTimeout   = 250 * time.Millisecond
+	outboundSMTPDialTimeout      = 2 * time.Second
+	outboundSMTPQuitWriteTimeout = 250 * time.Millisecond
+)
+
+// 出站 SMTP 各阶段超时，遵循 RFC 5321 §4.5.3.2 的要求：
+// 客户端必须按"每条命令 / 每个数据块"分别计时，而不能对整个邮件事务
+// 设置统一 Deadline——否则携带大附件（例如 1GB 附件）的邮件传输
+// 必然超过固定时限被误杀。按阶段计时后，整体超时自然随邮件大小线性扩展。
+//
+// 使用 var 而非 const，便于在不重新编译的情况下调整（RFC 5321 §4.5.3.2 SHOULD）。
+var (
+	// RFC 5321 §4.5.3.2.1：等待初始 220 问候。
+	// 许多服务器在高负载时会延迟发送 220，因此给足时间。
+	outboundSMTPGreetingTimeout = 5 * time.Minute
+	// RFC 5321 §4.5.3.2.2 / §4.5.3.2.3：单条命令（EHLO/HELO/MAIL/RCPT 等）
+	// 等待响应的超时。
+	outboundSMTPCommandTimeout = 5 * time.Minute
+	// RFC 5321 §4.5.3.2.4：发出 DATA 命令后等待 354 响应的超时。
+	outboundSMTPDataStartTimeout = 2 * time.Minute
+	// RFC 5321 §4.5.3.2.5：每个数据块写入的超时，随每次 Write 刷新，
+	// 因此大附件传输不会被误杀。
+	outboundSMTPDataBlockTimeout = 3 * time.Minute
+	// RFC 5321 §4.5.3.2.6：正文发送完毕后等待最终 250 的超时。
+	// 此时接收方通常正在做入库/投递处理，过早超时会引发重复投递。
+	outboundSMTPDataEndTimeout = 10 * time.Minute
 )
 
 // A Client represents a client connection to an SMTP server.
@@ -96,18 +118,20 @@ func DialTls(addr, domain, fromDomain string) (*Client, error) {
 // NewClient returns a new Client using an existing connection and host as a
 // server name to be used when authenticating.
 func NewClient(conn net.Conn, host, fromDomain string) (*Client, error) {
-	return newClientWithTimeout(conn, host, fromDomain, outboundSMTPTransactionTimeout)
-}
+	text := textproto.NewConn(conn)
 
-func newClientWithTimeout(conn net.Conn, host, fromDomain string, timeout time.Duration) (*Client, error) {
-	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
-		conn.Close()
+	// RFC 5321 §4.5.3.2.1：仅对初始 220 问候单独计时，
+	// 读取完成后立即清除，不影响后续命令与数据传输阶段。
+	if err := conn.SetReadDeadline(time.Now().Add(outboundSMTPGreetingTimeout)); err != nil {
+		text.Close()
 		return nil, err
 	}
-
-	text := textproto.NewConn(conn)
 	_, _, err := text.ReadResponse(220)
 	if err != nil {
+		text.Close()
+		return nil, err
+	}
+	if err := conn.SetReadDeadline(time.Time{}); err != nil {
 		text.Close()
 		return nil, err
 	}
@@ -160,6 +184,17 @@ func (c *Client) Hello(localName string) error {
 
 // cmd is a convenience function that sends a command and returns the response
 func (c *Client) cmd(expectCode int, format string, args ...any) (int, string, error) {
+	return c.cmdWithTimeout(expectCode, outboundSMTPCommandTimeout, format, args...)
+}
+
+// cmdWithTimeout 对单条命令的收发应用超时（RFC 5321 §4.5.3.2 要求的按命令计时）。
+// 命令结束后立即清除 Deadline，避免影响后续数据传输阶段。
+func (c *Client) cmdWithTimeout(expectCode int, timeout time.Duration, format string, args ...any) (int, string, error) {
+	if err := c.conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+		return 0, "", err
+	}
+	defer func() { _ = c.conn.SetDeadline(time.Time{}) }()
+
 	id, err := c.Text.Cmd(format, args...)
 	if err != nil {
 		return 0, "", err
@@ -339,7 +374,15 @@ type dataCloser struct {
 }
 
 func (d *dataCloser) Close() error {
-	d.WriteCloser.Close()
+	if err := d.WriteCloser.Close(); err != nil {
+		return err
+	}
+	// RFC 5321 §4.5.3.2.6：等待最终 250 响应的超时单独计时。
+	// 此时接收方通常正在做入库处理，过早超时会引发重复投递。
+	if err := d.c.conn.SetReadDeadline(time.Now().Add(outboundSMTPDataEndTimeout)); err != nil {
+		return err
+	}
+	defer func() { _ = d.c.conn.SetReadDeadline(time.Time{}) }()
 	_, _, err := d.c.Text.ReadResponse(250)
 	return err
 }
@@ -349,11 +392,54 @@ func (d *dataCloser) Close() error {
 // close the writer before calling any more methods on c. A call to
 // Data must be preceded by one or more calls to Rcpt.
 func (c *Client) Data() (io.WriteCloser, error) {
-	_, _, err := c.cmd(354, "DATA")
+	// RFC 5321 §4.5.3.2.4：等待 354 响应的超时单独计时。
+	_, _, err := c.cmdWithTimeout(354, outboundSMTPDataStartTimeout, "DATA")
 	if err != nil {
 		return nil, err
 	}
-	return &dataCloser{c, c.Text.DotWriter()}, nil
+	return &dataCloser{c, &dataBlockWriter{c: c, w: c.Text.DotWriter()}}, nil
+}
+
+// dataBlockWriter 在每个数据块写入前刷新写超时（RFC 5321 §4.5.3.2.5：
+// 每个数据块单独计时）。因此整体传输时限随邮件大小线性扩展，
+// 大附件不会被会话级 Deadline 误杀；而对端挂死时，
+// 最后一个数据块也会在超时内失败并释放连接。
+type dataBlockWriter struct {
+	c *Client
+	w io.WriteCloser
+}
+
+// outboundSMTPDataBlockSize 是单个数据块的大小。
+// 上层可能把整封邮件（含超大附件）一次性传入 Write，
+// 这里按固定块切分并逐块刷新超时，确保"每个数据块单独计时"
+// 的语义不依赖调用方的写入粒度。
+const outboundSMTPDataBlockSize = 32 * 1024
+
+func (d *dataBlockWriter) Write(p []byte) (int, error) {
+	written := 0
+	for len(p) > 0 {
+		chunk := p
+		if len(chunk) > outboundSMTPDataBlockSize {
+			chunk = chunk[:outboundSMTPDataBlockSize]
+		}
+		if err := d.c.conn.SetWriteDeadline(time.Now().Add(outboundSMTPDataBlockTimeout)); err != nil {
+			return written, err
+		}
+		n, err := d.w.Write(chunk)
+		written += n
+		if err != nil {
+			return written, err
+		}
+		p = p[n:]
+	}
+	return written, nil
+}
+
+func (d *dataBlockWriter) Close() error {
+	if err := d.c.conn.SetWriteDeadline(time.Now().Add(outboundSMTPDataBlockTimeout)); err != nil {
+		return err
+	}
+	return d.w.Close()
 }
 
 func finishDelivery(c *Client, w io.WriteCloser, msg []byte) error {

--- a/server/utils/smtp/smtp_test.go
+++ b/server/utils/smtp/smtp_test.go
@@ -77,27 +77,212 @@ func TestSendMailUnsafeUsesFinalDataResponseAsDeliveryResult(t *testing.T) {
 	}
 }
 
+// withShortTimeouts 临时调小各阶段超时用于测试，返回恢复函数。
+func withShortTimeouts(t *testing.T, greeting, command, dataStart, dataBlock, dataEnd time.Duration) {
+	t.Helper()
+	origGreeting, origCommand, origDataStart, origDataBlock, origDataEnd :=
+		outboundSMTPGreetingTimeout, outboundSMTPCommandTimeout, outboundSMTPDataStartTimeout,
+		outboundSMTPDataBlockTimeout, outboundSMTPDataEndTimeout
+	outboundSMTPGreetingTimeout = greeting
+	outboundSMTPCommandTimeout = command
+	outboundSMTPDataStartTimeout = dataStart
+	outboundSMTPDataBlockTimeout = dataBlock
+	outboundSMTPDataEndTimeout = dataEnd
+	t.Cleanup(func() {
+		outboundSMTPGreetingTimeout, outboundSMTPCommandTimeout, outboundSMTPDataStartTimeout,
+			outboundSMTPDataBlockTimeout, outboundSMTPDataEndTimeout =
+			origGreeting, origCommand, origDataStart, origDataBlock, origDataEnd
+	})
+}
+
+// 静默服务器（只建连不发 220）必须在问候超时内失败，
+// 对应 RFC 5321 §4.5.3.2.1。
 func TestNewClientBoundsSilentServer(t *testing.T) {
-	if outboundSMTPTransactionTimeout != 30*time.Second {
-		t.Fatalf("outbound SMTP transaction timeout = %v, want 30s", outboundSMTPTransactionTimeout)
-	}
+	withShortTimeouts(t, 50*time.Millisecond, 5*time.Minute, 2*time.Minute, 3*time.Minute, 10*time.Minute)
 
 	clientConn, serverConn := net.Pipe()
 	defer serverConn.Close()
 
 	start := time.Now()
-	client, err := newClientWithTimeout(clientConn, "silent.example", "example.com", 50*time.Millisecond)
+	client, err := NewClient(clientConn, "silent.example", "example.com")
 	duration := time.Since(start)
 	if client != nil {
 		client.Close()
-		t.Fatal("newClientWithTimeout() returned a client from a silent server")
+		t.Fatal("NewClient() returned a client from a silent server")
 	}
 	var netErr net.Error
 	if !errors.As(err, &netErr) || !netErr.Timeout() {
-		t.Fatalf("newClientWithTimeout() error = %v, want timeout", err)
+		t.Fatalf("NewClient() error = %v, want timeout", err)
 	}
 	if duration > time.Second {
-		t.Fatalf("newClientWithTimeout() took %v, want at most 1s", duration)
+		t.Fatalf("NewClient() took %v, want at most 1s", duration)
+	}
+}
+
+// 模拟一个"慢但健康"的下游：每个响应前都延迟一段时间。
+// 总耗时必然超过任何单阶段超时，但只要按命令/数据块分别计时（而非
+// 整个会话一个 Deadline），投递就应当成功。
+func startSlowSMTPServer(t *testing.T, phaseDelay time.Duration) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+
+	go func() {
+		defer listener.Close()
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		text := textproto.NewConn(conn)
+		defer text.Close()
+
+		steps := []struct {
+			expectPrefix string
+			response     string
+		}{
+			{"", "220 slow ESMTP ready"},
+			{"EHLO ", "250 slow"},
+			{"MAIL FROM:", "250 2.1.0 sender accepted"},
+			{"RCPT TO:", "250 2.1.5 recipient accepted"},
+			{"DATA", "354 end data with <CR><LF>.<CR><LF>"},
+		}
+		for _, step := range steps {
+			time.Sleep(phaseDelay)
+			if step.expectPrefix != "" {
+				if err := expectSMTPCommand(text, step.expectPrefix); err != nil {
+					return
+				}
+			}
+			if err := text.PrintfLine("%s", step.response); err != nil {
+				return
+			}
+		}
+
+		if _, err := io.ReadAll(text.DotReader()); err != nil {
+			return
+		}
+		time.Sleep(phaseDelay)
+		if err := text.PrintfLine("250 2.0.0 queued"); err != nil {
+			return
+		}
+		// 与已有用例一致：消息被接受后不等待 221。
+		buf := make([]byte, 1)
+		_, _ = conn.Read(buf)
+	}()
+
+	return listener.Addr().String()
+}
+
+// 各阶段分别计时后，一个每步都慢、但总时长超过单阶段超时的健康下游
+// 不应被误杀；这正是"整个会话统一 Deadline"会出问题的场景。
+func TestPhasedTimeoutsAllowSlowMultiPhaseTransaction(t *testing.T) {
+	const phaseDelay = 150 * time.Millisecond
+	// 每个阶段给足 3 倍余量，但单阶段超时（450ms）远小于总耗时（约 6*150ms=900ms）。
+	withShortTimeouts(t, 5*time.Second, 450*time.Millisecond, 450*time.Millisecond, 450*time.Millisecond, 450*time.Millisecond)
+
+	addr := startSlowSMTPServer(t, phaseDelay)
+
+	err := SendMailUnsafe(
+		"",
+		addr,
+		nil,
+		"sender@example.com",
+		"example.com",
+		[]string{"recipient@example.net"},
+		[]byte("From: sender@example.com\r\nTo: recipient@example.net\r\nSubject: slow\r\n\r\nbody\r\n"),
+	)
+	if err != nil {
+		t.Fatalf("SendMailUnsafe() = %v, want nil (slow but healthy server must not be killed)", err)
+	}
+}
+
+// 模拟下游在 354 之后停止读取数据：上传必须在单个数据块超时内失败，
+// 而不是永久阻塞。
+func startStalledDataServer(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() failed: %v", err)
+	}
+
+	go func() {
+		defer listener.Close()
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		text := textproto.NewConn(conn)
+		defer text.Close()
+
+		if err := text.PrintfLine("220 stalled ESMTP ready"); err != nil {
+			return
+		}
+		if err := expectSMTPCommand(text, "EHLO "); err != nil {
+			return
+		}
+		if err := text.PrintfLine("250 stalled"); err != nil {
+			return
+		}
+		if err := expectSMTPCommand(text, "MAIL FROM:"); err != nil {
+			return
+		}
+		if err := text.PrintfLine("250 2.1.0 sender accepted"); err != nil {
+			return
+		}
+		if err := expectSMTPCommand(text, "RCPT TO:"); err != nil {
+			return
+		}
+		if err := text.PrintfLine("250 2.1.5 recipient accepted"); err != nil {
+			return
+		}
+		if err := expectSMTPCommand(text, "DATA"); err != nil {
+			return
+		}
+		if err := text.PrintfLine("354 end data with <CR><LF>.<CR><LF>"); err != nil {
+			return
+		}
+
+		// 关键：354 之后停止读取，模拟下游挂死。
+		time.Sleep(30 * time.Second)
+	}()
+
+	return listener.Addr().String()
+}
+
+func TestStalledDataUploadFailsWithinDataBlockTimeout(t *testing.T) {
+	withShortTimeouts(t, 5*time.Second, time.Minute, time.Minute, 300*time.Millisecond, time.Minute)
+
+	addr := startStalledDataServer(t)
+
+	// 构造 1MB 正文，足以填满内核 TCP 发送缓冲区，
+	// 使写操作在下游停止读取后真正阻塞。
+	body := make([]byte, 0, 1<<20)
+	body = append(body, "From: sender@example.com\r\nTo: recipient@example.net\r\nSubject: stalled\r\n\r\n"...)
+	for len(body) < 1<<20 {
+		body = append(body, "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\r\n"...)
+	}
+
+	start := time.Now()
+	err := SendMailUnsafe("", addr, nil, "sender@example.com", "example.com", []string{"recipient@example.net"}, body)
+	duration := time.Since(start)
+
+	if err == nil {
+		t.Fatal("SendMailUnsafe() = nil, want timeout error against stalled server")
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("SendMailUnsafe() error = %v, want timeout", err)
+	}
+	if duration > 10*time.Second {
+		t.Fatalf("SendMailUnsafe() took %v, want failure within data-block timeout", duration)
 	}
 }
 

--- a/server/utils/smtp/smtp_test.go
+++ b/server/utils/smtp/smtp_test.go
@@ -77,6 +77,30 @@ func TestSendMailUnsafeUsesFinalDataResponseAsDeliveryResult(t *testing.T) {
 	}
 }
 
+func TestNewClientBoundsSilentServer(t *testing.T) {
+	if outboundSMTPTransactionTimeout != 30*time.Second {
+		t.Fatalf("outbound SMTP transaction timeout = %v, want 30s", outboundSMTPTransactionTimeout)
+	}
+
+	clientConn, serverConn := net.Pipe()
+	defer serverConn.Close()
+
+	start := time.Now()
+	client, err := newClientWithTimeout(clientConn, "silent.example", "example.com", 50*time.Millisecond)
+	duration := time.Since(start)
+	if client != nil {
+		client.Close()
+		t.Fatal("newClientWithTimeout() returned a client from a silent server")
+	}
+	var netErr net.Error
+	if !errors.As(err, &netErr) || !netErr.Timeout() {
+		t.Fatalf("newClientWithTimeout() error = %v, want timeout", err)
+	}
+	if duration > time.Second {
+		t.Fatalf("newClientWithTimeout() took %v, want at most 1s", duration)
+	}
+}
+
 func startSMTPTransactionServer(t *testing.T, dataResponse string, holdWithoutQuitReply bool) (string, <-chan error) {
 	t.Helper()
 


### PR DESCRIPTION
问题：
Go 标准库 net/smtp 风格的客户端在读取服务器响应时没有任何超时。
如果目标邮件服务器接受 TCP 连接后不返回任何数据（不发送 220 问候、
或收到 DATA 后不回 250），读操作会永久阻塞。

在单连接串行发送模型下，一次这样的挂死会导致整条发送通道停摆。

修复：
1. 新增常量统一管理出站超时：
   - outboundSMTPDialTimeout = 2s（TCP 建连，沿用原值）
   - outboundSMTPTransactionTimeout = 30s（命令交互，新增）
   - outboundSMTPQuitWriteTimeout = 250ms（QUIT 写入，沿用原值）
2. 新增 newClientWithTimeout()，在建立连接后通过 conn.SetDeadline() 为整个命令交互阶段设置 30 秒截止线
3. NewClient() 默认应用该超时；明文与 TLS 两条路径均生效
4. 超时后按投递失败处理，由上层重试/退避机制恢复，连接被释放

效果：下游挂死从『永久卡死、通道停摆』变为『30 秒内失败并重试』。
配合并发发送（每条连接独立），单个挂死只影响一个并发槽。

测试：
新增 TestNewClientBoundsSilentServer，验证对静默服务器在
超时内失败返回，-race 通过。